### PR TITLE
Add more options and optimization for our tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,10 +29,10 @@ jobs:
             api-level: 23
           - target: google_apis
             api-level: 29
-        include:
-          - os: macos-11.0
-            api-level: 30
-            target: google_apis
+#         include:
+#           - os: macos-11.0
+#             api-level: 30
+#             target: google_apis
           - os: macos-latest
             api-level: 24
             target: playstore

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ jobs:
 | `disable-autofill` | Optional | `false` | Whether to disable autofill - `true` or `false`. |
 | `longpress-timeout` | Optional | 500 | Longpress timeout in milliseconds. |
 | `enable-hw-keyboard` | Optional | `false` | Whether to enable the hw keyboard and disable soft keyboard - `true` or `false`. |
+| `enable-logcat` | Optional | `false` | Whether to read and save logcat output to `artifacts/logcat.log` |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ jobs:
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |
 | `disable-spellchecker` | Optional | `false` | Whether to disable spellchecker - `true` or `false`. |
 | `disable-autofill` | Optional | `false` | Whether to disable autofill - `true` or `false`. |
+| `longpress-timeout` | Optional | 500 | Longpress timeout in milliseconds. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ jobs:
 | `disable-spellchecker` | Optional | `false` | Whether to disable spellchecker - `true` or `false`. |
 | `disable-autofill` | Optional | `false` | Whether to disable autofill - `true` or `false`. |
 | `longpress-timeout` | Optional | 500 | Longpress timeout in milliseconds. |
+| `enable-hw-keyboard` | Optional | `false` | Whether to enable the hw keyboard and disable soft keyboard - `true` or `false`. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ jobs:
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |
 | `disable-spellchecker` | Optional | `false` | Whether to disable spellchecker - `true` or `false`. |
+| `disable-autofill` | Optional | `false` | Whether to disable autofill - `true` or `false`. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ jobs:
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |
+| `disable-spellchecker` | Optional | `false` | Whether to disable spellchecker - `true` or `false`. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jobs:
 | `target` | Optional | `default` | Target of the system image - `default`, `google_apis` or `playstore`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
+| `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -145,6 +145,27 @@ describe('disable-autofill validator tests', () => {
   });
 });
 
+describe('enable-hw-keyboard validator tests', () => {
+  it('Throws if enable-hw-keyboard is not a boolean', () => {
+    const func = () => {
+      validator.checkEnableHwKeyboard('yes');
+    };
+    expect(func).toThrowError(`Input for input.enable-hw-keyboard should be either 'true' or 'false'.`);
+  });
+
+  it('Validates successfully if enable-hw-keyboard is either true or false', () => {
+    const func1 = () => {
+      validator.checkEnableHwKeyboard('true');
+    };
+    expect(func1).not.toThrow();
+
+    const func2 = () => {
+      validator.checkEnableHwKeyboard('false');
+    };
+    expect(func2).not.toThrow();
+  });
+});
+
 describe('longpress-timeout validator tests', () => {
   it('Throws if longpress-timeout is not a number', () => {
     const func = () => {

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -124,6 +124,27 @@ describe('disable-spellchecker validator tests', () => {
   });
 });
 
+describe('disable-autofill validator tests', () => {
+  it('Throws if disable-autofill is not a boolean', () => {
+    const func = () => {
+      validator.checkDisableAutofill('yes');
+    };
+    expect(func).toThrowError(`Input for input.disable-autofill should be either 'true' or 'false'.`);
+  });
+
+  it('Validates successfully if disable-autofill is either true or false', () => {
+    const func1 = () => {
+      validator.checkDisableAutofill('true');
+    };
+    expect(func1).not.toThrow();
+
+    const func2 = () => {
+      validator.checkDisableAutofill('false');
+    };
+    expect(func2).not.toThrow();
+  });
+});
+
 describe('emulator-build validator tests', () => {
   it('Throws if emulator-build is not a number', () => {
     const func = () => {

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -145,6 +145,29 @@ describe('disable-autofill validator tests', () => {
   });
 });
 
+describe('longpress-timeout validator tests', () => {
+  it('Throws if longpress-timeout is not a number', () => {
+    const func = () => {
+      validator.checkLongPressTimeout('abc123');
+    };
+    expect(func).toThrowError(`Unexpected longpress-timeout: 'abc123'.`);
+  });
+
+  it('Throws if longpress-timeout is not an integer', () => {
+    const func = () => {
+      validator.checkLongPressTimeout('123.123');
+    };
+    expect(func).toThrowError(`Unexpected longpress-timeout: '123.123'.`);
+  });
+
+  it('Validates successfully with valid longpress-timeout', () => {
+    const func = () => {
+      validator.checkLongPressTimeout('6061023');
+    };
+    expect(func).not.toThrow();
+  });
+});
+
 describe('emulator-build validator tests', () => {
   it('Throws if emulator-build is not a number', () => {
     const func = () => {

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -103,6 +103,27 @@ describe('disable-animations validator tests', () => {
   });
 });
 
+describe('disable-spellchecker validator tests', () => {
+  it('Throws if disable-spellchecker is not a boolean', () => {
+    const func = () => {
+      validator.checkDisableSpellchecker('yes');
+    };
+    expect(func).toThrowError(`Input for input.disable-spellchecker should be either 'true' or 'false'.`);
+  });
+
+  it('Validates successfully if disable-spellchecker is either true or false', () => {
+    const func1 = () => {
+      validator.checkDisableSpellchecker('true');
+    };
+    expect(func1).not.toThrow();
+
+    const func2 = () => {
+      validator.checkDisableSpellchecker('false');
+    };
+    expect(func2).not.toThrow();
+  });
+});
+
 describe('emulator-build validator tests', () => {
   it('Throws if emulator-build is not a number', () => {
     const func = () => {

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -166,6 +166,27 @@ describe('enable-hw-keyboard validator tests', () => {
   });
 });
 
+describe('enable-logcat validator tests', () => {
+  it('Throws if enable-logcat is not a boolean', () => {
+    const func = () => {
+      validator.checkEnableLogcat('yes');
+    };
+    expect(func).toThrowError(`Input for input.enable-logcat should be either 'true' or 'false'.`);
+  });
+
+  it('Validates successfully if enable-logcat is either true or false', () => {
+    const func1 = () => {
+      validator.checkEnableLogcat('true');
+    };
+    expect(func1).not.toThrow();
+
+    const func2 = () => {
+      validator.checkEnableLogcat('false');
+    };
+    expect(func2).not.toThrow();
+  });
+});
+
 describe('longpress-timeout validator tests', () => {
   it('Throws if longpress-timeout is not a number', () => {
     const func = () => {

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   disable-autofill:
     description: Whether to disable autofill - `true` or `false`.
     default: 'false'
+  longpress-timeout:
+    description: Longpress timeout in milliseconds.
+    default: 500
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   disable-animations:
     description: 'whether to disable animations - true or false'
     default: 'true'
+  disable-spellchecker: 
+    description: Whether to disable spellchecker - `true` or `false`.
+    default: 'false'
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
     default: 'x86'
   profile:
     description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`'
+  cores:
+    description: 'the number of cores to use for the emulator'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   enable-hw-keyboard:
     description: Enable hw keyboard and disable soft keyboard - `true` or `false`.
     default: 'false'
+  enable-logcat:
+    description: Enable reading and saving logcat output to `artifacts/logcat.log`.
+    default: 'false'
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   disable-spellchecker: 
     description: Whether to disable spellchecker - `true` or `false`.
     default: 'false'
+  disable-autofill:
+    description: Whether to disable autofill - `true` or `false`.
+    default: 'false'
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   longpress-timeout:
     description: Longpress timeout in milliseconds.
     default: 500
+  enable-hw-keyboard:
+    description: Enable hw keyboard and disable soft keyboard - `true` or `false`.
+    default: 'false'
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,7 +34,7 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations) {
+function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -65,6 +65,9 @@ function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdNa
             yield exec.exec(`adb shell settings put global window_animation_scale 0.0`);
             yield exec.exec(`adb shell settings put global transition_animation_scale 0.0`);
             yield exec.exec(`adb shell settings put global animator_duration_scale 0.0`);
+        }
+        if (disableSpellChecker) {
+            yield exec.exec(`adb shell settings put secure spell_checker_enabled 0`);
         }
     });
 }

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,7 +34,7 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker) {
+function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -68,6 +68,9 @@ function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdNa
         }
         if (disableSpellChecker) {
             yield exec.exec(`adb shell settings put secure spell_checker_enabled 0`);
+        }
+        if (disableAutofill) {
+            yield exec.exec(`adb shell settings put secure autofill_service null`);
         }
     });
 }

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,13 +34,16 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout) {
+function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
         const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
         console.log(`Creating AVD.`);
         yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
+        if (enableHwKeyboard) {
+            yield exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+        }
         // start emulator
         console.log('Starting emulator.');
         // turn off hardware acceleration on Linux
@@ -74,6 +77,9 @@ function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdNa
         }
         if (longPressTimeout) {
             yield exec.exec(`adb shell settings put secure long_press_timeout ${longPressTimeout}`);
+        }
+        if (enableHwKeyboard) {
+            yield exec.exec(`adb shell settings put secure show_ime_with_hard_keyboard 0`);
         }
     });
 }

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -31,10 +31,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.killEmulator = exports.launchEmulator = void 0;
 const exec = __importStar(require("@actions/exec"));
 const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
+let ENABLE_LOGCAT = false;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard) {
+function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -84,6 +85,10 @@ function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize
         if (enableHwKeyboard) {
             yield exec.exec(`adb shell settings put secure show_ime_with_hard_keyboard 0`);
         }
+        if (enableLogcat) {
+            ENABLE_LOGCAT = enableLogcat;
+            yield startLogcat();
+        }
     });
 }
 exports.launchEmulator = launchEmulator;
@@ -93,6 +98,9 @@ exports.launchEmulator = launchEmulator;
 function killEmulator() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            if (ENABLE_LOGCAT) {
+                yield stopLogcat();
+            }
             yield exec.exec(`adb -s emulator-5554 emu kill`);
         }
         catch (error) {
@@ -141,4 +149,22 @@ function waitForDevice() {
 }
 function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
+}
+function startLogcat() {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log('Starting logcat read process');
+        yield exec.exec(`mkdir -p artifacts`);
+        try {
+            yield exec.exec(`sh -c \\"adb logcat -v time > artifacts/logcat.log &"`);
+        }
+        catch (error) {
+            console.log(error.message);
+        }
+    });
+}
+function stopLogcat() {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log('Stopping logcat read process');
+        yield exec.exec(`sh -c "jobs -p | xargs kill"`);
+    });
 }

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,13 +34,16 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard) {
+function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
         const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
         console.log(`Creating AVD.`);
         yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
+        if (cores) {
+            yield exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+        }
         if (enableHwKeyboard) {
             yield exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
         }

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,7 +34,7 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill) {
+function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -71,6 +71,9 @@ function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdNa
         }
         if (disableAutofill) {
             yield exec.exec(`adb shell settings put secure autofill_service null`);
+        }
+        if (longPressTimeout) {
+            yield exec.exec(`adb shell settings put secure long_press_timeout ${longPressTimeout}`);
         }
     });
 }

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkEnableHwKeyboard = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkEnableLogcat = exports.checkEnableHwKeyboard = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -49,6 +49,12 @@ function checkEnableHwKeyboard(enableHwKeyboard) {
     }
 }
 exports.checkEnableHwKeyboard = checkEnableHwKeyboard;
+function checkEnableLogcat(enableLogcat) {
+    if (!isValidBoolean(enableLogcat)) {
+        throw new Error(`Input for input.enable-logcat should be either 'true' or 'false'.`);
+    }
+}
+exports.checkEnableLogcat = checkEnableLogcat;
 function checkLongPressTimeout(timeout) {
     if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
         throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -37,6 +37,12 @@ function checkDisableSpellchecker(disableSpellchecker) {
     }
 }
 exports.checkDisableSpellchecker = checkDisableSpellchecker;
+function checkDisableAutofill(disableAutofill) {
+    if (!isValidBoolean(disableAutofill)) {
+        throw new Error(`Input for input.disable-autofill should be either 'true' or 'false'.`);
+    }
+}
+exports.checkDisableAutofill = checkDisableAutofill;
 function checkEmulatorBuild(emulatorBuild) {
     if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
         throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -26,14 +26,23 @@ function checkArch(arch) {
 }
 exports.checkArch = checkArch;
 function checkDisableAnimations(disableAnimations) {
-    if (disableAnimations !== 'true' && disableAnimations !== 'false') {
+    if (!isValidBoolean(disableAnimations)) {
         throw new Error(`Input for input.disable-animations should be either 'true' or 'false'.`);
     }
 }
 exports.checkDisableAnimations = checkDisableAnimations;
+function checkDisableSpellchecker(disableSpellchecker) {
+    if (!isValidBoolean(disableSpellchecker)) {
+        throw new Error(`Input for input.disable-spellchecker should be either 'true' or 'false'.`);
+    }
+}
+exports.checkDisableSpellchecker = checkDisableSpellchecker;
 function checkEmulatorBuild(emulatorBuild) {
     if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
         throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);
     }
 }
 exports.checkEmulatorBuild = checkEmulatorBuild;
+function isValidBoolean(value) {
+    return value === 'true' || value === 'false';
+}

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -43,6 +43,12 @@ function checkDisableAutofill(disableAutofill) {
     }
 }
 exports.checkDisableAutofill = checkDisableAutofill;
+function checkLongPressTimeout(timeout) {
+    if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
+        throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);
+    }
+}
+exports.checkLongPressTimeout = checkLongPressTimeout;
 function checkEmulatorBuild(emulatorBuild) {
     if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
         throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkEnableHwKeyboard = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -43,6 +43,12 @@ function checkDisableAutofill(disableAutofill) {
     }
 }
 exports.checkDisableAutofill = checkDisableAutofill;
+function checkEnableHwKeyboard(enableHwKeyboard) {
+    if (!isValidBoolean(enableHwKeyboard)) {
+        throw new Error(`Input for input.enable-hw-keyboard should be either 'true' or 'false'.`);
+    }
+}
+exports.checkEnableHwKeyboard = checkEnableHwKeyboard;
 function checkLongPressTimeout(timeout) {
     if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
         throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -85,6 +85,11 @@ function run() {
             input_validator_1.checkEnableHwKeyboard(enableHwKeyboardInput);
             const enableHwKeyboard = enableHwKeyboardInput === 'true';
             console.log(`enable hw keyboard: ${enableHwKeyboard}`);
+            // enable logcat
+            const enableLogcatInput = core.getInput('enable-logcat');
+            input_validator_1.checkEnableLogcat(enableLogcatInput);
+            const enableLogcat = enableLogcatInput === 'true';
+            console.log(`enable logcat: ${enableLogcat}`);
             // disable spellchecker
             const disableSpellcheckerInput = core.getInput('disable-spellchecker');
             input_validator_1.checkDisableSpellchecker(disableSpellcheckerInput);
@@ -135,7 +140,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,6 +77,11 @@ function run() {
             input_validator_1.checkDisableAnimations(disableAnimationsInput);
             const disableAnimations = disableAnimationsInput === 'true';
             console.log(`disable animations: ${disableAnimations}`);
+            // disable spellchecker
+            const disableSpellcheckerInput = core.getInput('disable-spellchecker');
+            input_validator_1.checkDisableSpellchecker(disableSpellcheckerInput);
+            const disableSpellchecker = disableSpellcheckerInput === 'true';
+            console.log(`disable spellchecker: ${disableSpellchecker}`);
             // emulator build
             const emulatorBuildInput = core.getInput('emulator-build');
             if (emulatorBuildInput) {
@@ -112,7 +117,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -87,6 +87,11 @@ function run() {
             input_validator_1.checkDisableAutofill(disableAutofillInput);
             const disableAutofill = disableAutofillInput === 'true';
             console.log(`disable autofill: ${disableAutofill}`);
+            // update longpress timeout
+            const longPressTimeoutInput = core.getInput('longpress-timeout');
+            input_validator_1.checkLongPressTimeout(longPressTimeoutInput);
+            const longPressTimeout = Number(longPressTimeoutInput);
+            console.log(`update longpress-timeout: ${longPressTimeoutInput}`);
             // emulator build
             const emulatorBuildInput = core.getInput('emulator-build');
             if (emulatorBuildInput) {
@@ -122,7 +127,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,6 +77,11 @@ function run() {
             input_validator_1.checkDisableAnimations(disableAnimationsInput);
             const disableAnimations = disableAnimationsInput === 'true';
             console.log(`disable animations: ${disableAnimations}`);
+            // disable ime
+            const enableHwKeyboardInput = core.getInput('enable-hw-keyboard');
+            input_validator_1.checkEnableHwKeyboard(enableHwKeyboardInput);
+            const enableHwKeyboard = enableHwKeyboardInput === 'true';
+            console.log(`enable hw keyboard: ${enableHwKeyboard}`);
             // disable spellchecker
             const disableSpellcheckerInput = core.getInput('disable-spellchecker');
             input_validator_1.checkDisableSpellchecker(disableSpellcheckerInput);
@@ -127,7 +132,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,6 +63,9 @@ function run() {
             // Hardware profile used for creating the AVD
             const profile = core.getInput('profile');
             console.log(`Hardware profile: ${profile}`);
+            // Number of cores to use for emulator
+            const cores = core.getInput('cores');
+            console.log(`Cores: ${cores}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -132,7 +135,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -82,6 +82,11 @@ function run() {
             input_validator_1.checkDisableSpellchecker(disableSpellcheckerInput);
             const disableSpellchecker = disableSpellcheckerInput === 'true';
             console.log(`disable spellchecker: ${disableSpellchecker}`);
+            // disable autofill
+            const disableAutofillInput = core.getInput('disable-autofill');
+            input_validator_1.checkDisableAutofill(disableAutofillInput);
+            const disableAutofill = disableAutofillInput === 'true';
+            console.log(`disable autofill: ${disableAutofill}`);
             // emulator build
             const emulatorBuildInput = core.getInput('emulator-build');
             if (emulatorBuildInput) {
@@ -117,7 +122,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -15,7 +15,8 @@ export async function launchEmulator(
   emulatorOptions: string,
   disableAnimations: boolean,
   disableSpellChecker: boolean,
-  disableAutofill: boolean
+  disableAutofill: boolean,
+  longPressTimeout: number
 ): Promise<void> {
   // create a new AVD
   const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -59,6 +60,9 @@ export async function launchEmulator(
   }
   if (disableAutofill) {
     await exec.exec(`adb shell settings put secure autofill_service null`);
+  }
+  if (longPressTimeout) {
+    await exec.exec(`adb shell settings put secure long_press_timeout ${longPressTimeout}`);
   }
 }
 

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -10,6 +10,7 @@ export async function launchEmulator(
   target: string,
   arch: string,
   profile: string,
+  cores: string,
   sdcardPathOrSize: string,
   avdName: string,
   emulatorOptions: string,
@@ -26,6 +27,10 @@ export async function launchEmulator(
   await exec.exec(
     `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
   );
+
+  if (cores) {
+    await exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+  }
 
   if (enableHwKeyboard) {
     await exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -16,7 +16,8 @@ export async function launchEmulator(
   disableAnimations: boolean,
   disableSpellChecker: boolean,
   disableAutofill: boolean,
-  longPressTimeout: number
+  longPressTimeout: number,
+  enableHwKeyboard: boolean
 ): Promise<void> {
   // create a new AVD
   const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -25,6 +26,10 @@ export async function launchEmulator(
   await exec.exec(
     `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
   );
+
+  if (enableHwKeyboard) {
+    await exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+  }
 
   // start emulator
   console.log('Starting emulator.');
@@ -63,6 +68,9 @@ export async function launchEmulator(
   }
   if (longPressTimeout) {
     await exec.exec(`adb shell settings put secure long_press_timeout ${longPressTimeout}`);
+  }
+  if (enableHwKeyboard) {
+    await exec.exec(`adb shell settings put secure show_ime_with_hard_keyboard 0`);
   }
 }
 

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -13,7 +13,8 @@ export async function launchEmulator(
   sdcardPathOrSize: string,
   avdName: string,
   emulatorOptions: string,
-  disableAnimations: boolean
+  disableAnimations: boolean,
+  disableSpellChecker: boolean
 ): Promise<void> {
   // create a new AVD
   const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -51,6 +52,9 @@ export async function launchEmulator(
     await exec.exec(`adb shell settings put global window_animation_scale 0.0`);
     await exec.exec(`adb shell settings put global transition_animation_scale 0.0`);
     await exec.exec(`adb shell settings put global animator_duration_scale 0.0`);
+  }
+  if (disableSpellChecker) {
+    await exec.exec(`adb shell settings put secure spell_checker_enabled 0`);
   }
 }
 

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -14,7 +14,8 @@ export async function launchEmulator(
   avdName: string,
   emulatorOptions: string,
   disableAnimations: boolean,
-  disableSpellChecker: boolean
+  disableSpellChecker: boolean,
+  disableAutofill: boolean
 ): Promise<void> {
   // create a new AVD
   const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -55,6 +56,9 @@ export async function launchEmulator(
   }
   if (disableSpellChecker) {
     await exec.exec(`adb shell settings put secure spell_checker_enabled 0`);
+  }
+  if (disableAutofill) {
+    await exec.exec(`adb shell settings put secure autofill_service null`);
   }
 }
 

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -24,8 +24,14 @@ export function checkArch(arch: string): void {
 }
 
 export function checkDisableAnimations(disableAnimations: string): void {
-  if (disableAnimations !== 'true' && disableAnimations !== 'false') {
+  if (!isValidBoolean(disableAnimations)) {
     throw new Error(`Input for input.disable-animations should be either 'true' or 'false'.`);
+  }
+}
+
+export function checkDisableSpellchecker(disableSpellchecker: string): void {
+  if (!isValidBoolean(disableSpellchecker)) {
+    throw new Error(`Input for input.disable-spellchecker should be either 'true' or 'false'.`);
   }
 }
 
@@ -33,4 +39,8 @@ export function checkEmulatorBuild(emulatorBuild: string): void {
   if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
     throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);
   }
+}
+
+function isValidBoolean(value: string): boolean {
+  return value === 'true' || value === 'false';
 }

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -47,6 +47,12 @@ export function checkEnableHwKeyboard(enableHwKeyboard: string): void {
   }
 }
 
+export function checkEnableLogcat(enableLogcat: string): void {
+  if (!isValidBoolean(enableLogcat)) {
+    throw new Error(`Input for input.enable-logcat should be either 'true' or 'false'.`);
+  }
+}
+
 export function checkLongPressTimeout(timeout: string): void {
   if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
     throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -41,6 +41,12 @@ export function checkDisableAutofill(disableAutofill: string): void {
   }
 }
 
+export function checkLongPressTimeout(timeout: string): void {
+  if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
+    throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);
+  }
+}
+
 export function checkEmulatorBuild(emulatorBuild: string): void {
   if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
     throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -41,6 +41,12 @@ export function checkDisableAutofill(disableAutofill: string): void {
   }
 }
 
+export function checkEnableHwKeyboard(enableHwKeyboard: string): void {
+  if (!isValidBoolean(enableHwKeyboard)) {
+    throw new Error(`Input for input.enable-hw-keyboard should be either 'true' or 'false'.`);
+  }
+}
+
 export function checkLongPressTimeout(timeout: string): void {
   if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
     throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -35,6 +35,12 @@ export function checkDisableSpellchecker(disableSpellchecker: string): void {
   }
 }
 
+export function checkDisableAutofill(disableAutofill: string): void {
+  if (!isValidBoolean(disableAutofill)) {
+    throw new Error(`Input for input.disable-autofill should be either 'true' or 'false'.`);
+  }
+}
+
 export function checkEmulatorBuild(emulatorBuild: string): void {
   if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
     throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import { installAndroidSdk } from './sdk-installer';
-import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild } from './input-validator';
+import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker } from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
 import { parseScript } from './script-parser';
@@ -57,6 +57,12 @@ async function run() {
     const disableAnimations = disableAnimationsInput === 'true';
     console.log(`disable animations: ${disableAnimations}`);
 
+    // disable spellchecker
+    const disableSpellcheckerInput = core.getInput('disable-spellchecker');
+    checkDisableSpellchecker(disableSpellcheckerInput);
+    const disableSpellchecker = disableSpellcheckerInput === 'true';
+    console.log(`disable spellchecker: ${disableSpellchecker}`);
+
     // emulator build
     const emulatorBuildInput = core.getInput('emulator-build');
     if (emulatorBuildInput) {
@@ -98,7 +104,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
+    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker);
 
     // execute the custom script
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,16 @@
 import * as core from '@actions/core';
 import { installAndroidSdk } from './sdk-installer';
-import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker, checkDisableAutofill, checkLongPressTimeout } from './input-validator';
+import {
+  checkApiLevel,
+  checkTarget,
+  checkArch,
+  checkDisableAnimations,
+  checkEmulatorBuild,
+  checkDisableSpellchecker,
+  checkDisableAutofill,
+  checkLongPressTimeout,
+  checkEnableHwKeyboard
+} from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
 import { parseScript } from './script-parser';
@@ -56,6 +66,12 @@ async function run() {
     checkDisableAnimations(disableAnimationsInput);
     const disableAnimations = disableAnimationsInput === 'true';
     console.log(`disable animations: ${disableAnimations}`);
+
+    // disable ime
+    const enableHwKeyboardInput = core.getInput('enable-hw-keyboard');
+    checkEnableHwKeyboard(enableHwKeyboardInput);
+    const enableHwKeyboard = enableHwKeyboardInput === 'true';
+    console.log(`enable hw keyboard: ${enableHwKeyboard}`);
 
     // disable spellchecker
     const disableSpellcheckerInput = core.getInput('disable-spellchecker');
@@ -116,7 +132,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout);
+    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
 
     // execute the custom script
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ import {
   checkDisableSpellchecker,
   checkDisableAutofill,
   checkLongPressTimeout,
-  checkEnableHwKeyboard
+  checkEnableHwKeyboard,
+  checkEnableLogcat
 } from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
@@ -76,6 +77,12 @@ async function run() {
     checkEnableHwKeyboard(enableHwKeyboardInput);
     const enableHwKeyboard = enableHwKeyboardInput === 'true';
     console.log(`enable hw keyboard: ${enableHwKeyboard}`);
+
+    // enable logcat
+    const enableLogcatInput = core.getInput('enable-logcat');
+    checkEnableLogcat(enableLogcatInput);
+    const enableLogcat = enableLogcatInput === 'true';
+    console.log(`enable logcat: ${enableLogcat}`);
 
     // disable spellchecker
     const disableSpellcheckerInput = core.getInput('disable-spellchecker');
@@ -149,7 +156,8 @@ async function run() {
       disableSpellchecker,
       disableAutofill,
       longPressTimeout,
-      enableHwKeyboard
+      enableHwKeyboard,
+      enableLogcat
     );
 
     // execute the custom script

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,10 @@ async function run() {
     const profile = core.getInput('profile');
     console.log(`Hardware profile: ${profile}`);
 
+    // Number of cores to use for emulator
+    const cores = core.getInput('cores');
+    console.log(`Cores: ${cores}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -132,7 +136,21 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard);
+    await launchEmulator(
+      apiLevel,
+      target,
+      arch,
+      profile,
+      cores,
+      sdcardPathOrSize,
+      avdName,
+      emulatorOptions,
+      disableAnimations,
+      disableSpellchecker,
+      disableAutofill,
+      longPressTimeout,
+      enableHwKeyboard
+    );
 
     // execute the custom script
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import { installAndroidSdk } from './sdk-installer';
-import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker, checkDisableAutofill } from './input-validator';
+import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker, checkDisableAutofill, checkLongPressTimeout } from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
 import { parseScript } from './script-parser';
@@ -69,6 +69,12 @@ async function run() {
     const disableAutofill = disableAutofillInput === 'true';
     console.log(`disable autofill: ${disableAutofill}`);
 
+    // update longpress timeout
+    const longPressTimeoutInput = core.getInput('longpress-timeout');
+    checkLongPressTimeout(longPressTimeoutInput);
+    const longPressTimeout = Number(longPressTimeoutInput);
+    console.log(`update longpress-timeout: ${longPressTimeoutInput}`);
+
     // emulator build
     const emulatorBuildInput = core.getInput('emulator-build');
     if (emulatorBuildInput) {
@@ -110,7 +116,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill);
+    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout);
 
     // execute the custom script
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import { installAndroidSdk } from './sdk-installer';
-import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker } from './input-validator';
+import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations, checkEmulatorBuild, checkDisableSpellchecker, checkDisableAutofill } from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
 import { parseScript } from './script-parser';
@@ -63,6 +63,12 @@ async function run() {
     const disableSpellchecker = disableSpellcheckerInput === 'true';
     console.log(`disable spellchecker: ${disableSpellchecker}`);
 
+    // disable autofill
+    const disableAutofillInput = core.getInput('disable-autofill');
+    checkDisableAutofill(disableAutofillInput);
+    const disableAutofill = disableAutofillInput === 'true';
+    console.log(`disable autofill: ${disableAutofill}`);
+
     // emulator build
     const emulatorBuildInput = core.getInput('emulator-build');
     if (emulatorBuildInput) {
@@ -104,7 +110,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker);
+    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill);
 
     // execute the custom script
     try {


### PR DESCRIPTION
- Added options for disabling spellcheck, autofill, enabling hw keyboard (and disabling soft keyboard), changing longpress timeout
- Added option to modify the number of cores used by the emulator (because GitHub macOS VM has 3 cores, the emulator defaults to 1 core, which is not stable)
- Added option to enable reading and saving logcat output

Note: The lib folder is generated by npm. A release branch called `release/v2-doist` has been created from this branch to use these changes until a tag is ready.

Once this is merged to main, I will tag a version so we can use that in our repos. Since this is our fork, we can control the tags (correct me if I'm wrong). @goncalossilva and @Doist/android, would appreciate your thoughts on this part as well.

Given the amount of new options here, I wouldn't be surprised if some of these changes get rejected upstream.