### PR TITLE
Add a ram-size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ jobs:
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
+| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,8 @@ inputs:
     description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`'
   cores:
     description: 'the number of cores to use for the emulator'
+  ram-size:
+    description: 'the size of RAM for this AVD'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,7 +35,7 @@ let ENABLE_LOGCAT = false;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -44,6 +44,9 @@ function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize
         yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
         if (cores) {
             yield exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+        }
+        if (ramSize) {
+            yield exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
         }
         if (enableHwKeyboard) {
             yield exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -66,6 +66,8 @@ function run() {
             // Number of cores to use for emulator
             const cores = core.getInput('cores');
             console.log(`Cores: ${cores}`);
+            const ramSize = core.getInput('ram-size');
+            console.log(`RAM size: ${ramSize}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -140,7 +142,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -12,6 +12,7 @@ export async function launchEmulator(
   arch: string,
   profile: string,
   cores: string,
+  ramSize: string,
   sdcardPathOrSize: string,
   avdName: string,
   emulatorOptions: string,
@@ -32,6 +33,10 @@ export async function launchEmulator(
 
   if (cores) {
     await exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+  }
+
+  if (ramSize) {
+    await exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
   }
 
   if (enableHwKeyboard) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,9 @@ async function run() {
     const cores = core.getInput('cores');
     console.log(`Cores: ${cores}`);
 
+    const ramSize = core.getInput('ram-size');
+    console.log(`RAM size: ${ramSize}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -149,6 +152,7 @@ async function run() {
       arch,
       profile,
       cores,
+      ramSize,
       sdcardPathOrSize,
       avdName,
       emulatorOptions,


### PR DESCRIPTION
Wanted to increase the RAM on the emulator because it seemed to be running out of RAM in one of the runs, so decided to add this as an option as well.

There's no input validation on this field, same as the field for SD Card size.