### PR TITLE
Add options for hw.ramSize, vm.heapSize, and print config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ jobs:
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in MB (`hw.ramSize` in config.ini). - e.g. `2048` |
+| `vm-heap-size` | Optional | N/A | Size of VM heap for apps in this AVD, in MB (`vm.heapSize` in config.ini). - e.g. `512` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
-| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
+| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in MB (`hw.ramSize` in config.ini). - e.g. `2048` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ jobs:
 | `longpress-timeout` | Optional | 500 | Longpress timeout in milliseconds. |
 | `enable-hw-keyboard` | Optional | `false` | Whether to enable the hw keyboard and disable soft keyboard - `true` or `false`. |
 | `enable-logcat` | Optional | `false` | Whether to read and save logcat output to `artifacts/logcat.log` |
+| `print-config-ini` | Optional | `false` | Whether to print `config.ini` and `hardware-qemu.ini` upon emulator start. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
 | `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
   enable-logcat:
     description: Enable reading and saving logcat output to `artifacts/logcat.log`.
     default: 'false'
+  print-config-ini:
+    description: Print config.ini and harware-qemu.ini
+    default: 'false'
   emulator-build:
     description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   cores:
     description: 'the number of cores to use for the emulator'
   ram-size:
-    description: 'the size of RAM for this AVD'
+    description: 'the size of RAM for this AVD in MB'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
     description: 'the number of cores to use for the emulator'
   ram-size:
     description: 'the size of RAM for this AVD in MB'
+  vm-heap-size:
+    description: 'the VM heap size for this AVD in MB'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,7 +35,7 @@ let ENABLE_LOGCAT = false;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -47,6 +47,9 @@ function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardP
         }
         if (ramSize) {
             yield exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+        }
+        if (vmHeapSize) {
+            yield exec.exec(`sh -c \\"printf 'vm.heapSize=${vmHeapSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
         }
         if (enableHwKeyboard) {
             yield exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,7 +35,7 @@ let ENABLE_LOGCAT = false;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellChecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat, printConfigIni) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -69,6 +69,11 @@ function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapS
                 }
             }
         });
+        if (printConfigIni) {
+            // hardware-qemu.ini is generated after emulator is started
+            yield exec.exec(`sh -c \\"more ~/.android/avd/"${avdName}".avd"/config.ini`);
+            yield exec.exec(`sh -c \\"more ~/.android/avd/"${avdName}".avd"/hardware-qemu.ini`);
+        }
         // wait for emulator to complete booting
         yield waitForDevice();
         yield exec.exec(`adb shell input keyevent 82`);

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkEnableLogcat = exports.checkEnableHwKeyboard = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
+exports.checkEmulatorBuild = exports.checkLongPressTimeout = exports.checkPrintConfigIni = exports.checkEnableLogcat = exports.checkEnableHwKeyboard = exports.checkDisableAutofill = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
@@ -55,6 +55,12 @@ function checkEnableLogcat(enableLogcat) {
     }
 }
 exports.checkEnableLogcat = checkEnableLogcat;
+function checkPrintConfigIni(printConfigIni) {
+    if (!isValidBoolean(printConfigIni)) {
+        throw new Error(`Input for input.print-config-ini should be either 'true' or 'false'.`);
+    }
+}
+exports.checkPrintConfigIni = checkPrintConfigIni;
 function checkLongPressTimeout(timeout) {
     if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
         throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -94,6 +94,10 @@ function run() {
             input_validator_1.checkEnableLogcat(enableLogcatInput);
             const enableLogcat = enableLogcatInput === 'true';
             console.log(`enable logcat: ${enableLogcat}`);
+            const printConfigIniInput = core.getInput('print-config-ini');
+            input_validator_1.checkPrintConfigIni(printConfigIniInput);
+            const printConfigIni = printConfigIniInput === 'true';
+            console.log(`print config.ini: ${printConfigIni}`);
             // disable spellchecker
             const disableSpellcheckerInput = core.getInput('disable-spellchecker');
             input_validator_1.checkDisableSpellchecker(disableSpellcheckerInput);
@@ -144,7 +148,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat, printConfigIni);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/lib/main.js
+++ b/lib/main.js
@@ -68,6 +68,8 @@ function run() {
             console.log(`Cores: ${cores}`);
             const ramSize = core.getInput('ram-size');
             console.log(`RAM size: ${ramSize}`);
+            const vmHeapSize = core.getInput('vm-heap-size');
+            console.log(`VM heap size: ${vmHeapSize}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -142,7 +144,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, vmHeapSize, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations, disableSpellchecker, disableAutofill, longPressTimeout, enableHwKeyboard, enableLogcat);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -22,7 +22,8 @@ export async function launchEmulator(
   disableAutofill: boolean,
   longPressTimeout: number,
   enableHwKeyboard: boolean,
-  enableLogcat: boolean
+  enableLogcat: boolean,
+  printConfigIni: boolean
 ): Promise<void> {
   // create a new AVD
   const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
@@ -65,6 +66,12 @@ export async function launchEmulator(
       }
     }
   });
+
+  if (printConfigIni) {
+    // hardware-qemu.ini is generated after emulator is started
+    await exec.exec(`sh -c \\"more ~/.android/avd/"${avdName}".avd"/config.ini`);
+    await exec.exec(`sh -c \\"more ~/.android/avd/"${avdName}".avd"/hardware-qemu.ini`);
+  }
 
   // wait for emulator to complete booting
   await waitForDevice();

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -13,6 +13,7 @@ export async function launchEmulator(
   profile: string,
   cores: string,
   ramSize: string,
+  vmHeapSize: string,
   sdcardPathOrSize: string,
   avdName: string,
   emulatorOptions: string,
@@ -37,6 +38,10 @@ export async function launchEmulator(
 
   if (ramSize) {
     await exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+  }
+
+  if (vmHeapSize) {
+    await exec.exec(`sh -c \\"printf 'vm.heapSize=${vmHeapSize}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
   }
 
   if (enableHwKeyboard) {

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -53,6 +53,12 @@ export function checkEnableLogcat(enableLogcat: string): void {
   }
 }
 
+export function checkPrintConfigIni(printConfigIni: string): void {
+  if (!isValidBoolean(printConfigIni)) {
+    throw new Error(`Input for input.print-config-ini should be either 'true' or 'false'.`);
+  }
+}
+
 export function checkLongPressTimeout(timeout: string): void {
   if (isNaN(Number(timeout)) || !Number.isInteger(Number(timeout))) {
     throw new Error(`Unexpected longpress-timeout: '${timeout}'.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {
   checkApiLevel,
   checkTarget,
   checkArch,
+  checkPrintConfigIni,
   checkDisableAnimations,
   checkEmulatorBuild,
   checkDisableSpellchecker,
@@ -90,6 +91,11 @@ async function run() {
     const enableLogcat = enableLogcatInput === 'true';
     console.log(`enable logcat: ${enableLogcat}`);
 
+    const printConfigIniInput = core.getInput('print-config-ini');
+    checkPrintConfigIni(printConfigIniInput);
+    const printConfigIni = printConfigIniInput === 'true';
+    console.log(`print config.ini: ${printConfigIni}`);
+
     // disable spellchecker
     const disableSpellcheckerInput = core.getInput('disable-spellchecker');
     checkDisableSpellchecker(disableSpellcheckerInput);
@@ -165,7 +171,8 @@ async function run() {
       disableAutofill,
       longPressTimeout,
       enableHwKeyboard,
-      enableLogcat
+      enableLogcat,
+      printConfigIni
     );
 
     // execute the custom script

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,9 @@ async function run() {
     const ramSize = core.getInput('ram-size');
     console.log(`RAM size: ${ramSize}`);
 
+    const vmHeapSize = core.getInput('vm-heap-size');
+    console.log(`VM heap size: ${vmHeapSize}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -153,6 +156,7 @@ async function run() {
       profile,
       cores,
       ramSize,
+      vmHeapSize,
       sdcardPathOrSize,
       avdName,
       emulatorOptions,


### PR DESCRIPTION
- Allow increasing RAM and VM heap size for the AVD
- To facilitate debugging these options, allow printing `config.ini` and `hardware-qemu.ini` that is generated when AVD is launched. `hardware-qemu.ini` is the source of truth _for some options_ in the AVD and if an option isn't set correctly, it might not reflect the same property value as `config.ini`.

